### PR TITLE
fixes issue #18

### DIFF
--- a/Sources/String+Attributer.swift
+++ b/Sources/String+Attributer.swift
@@ -295,7 +295,7 @@ public extension String {
      
      -parameter string: The string that will be added
      */
-    public func append(_ string: String) -> Attributer {
+    public func append(string: String) -> Attributer {
         return attributer.append(string)
     }
     


### PR DESCRIPTION
This PR prevents AttributedTextView from conflicting with Swift's [append(_:)](https://developer.apple.com/documentation/swift/array/1538872-append)

The fix doesn't require changes in current Demo project or Readme, because each item being "appended" there is an Attributer.
But it affects cases when you start creating "attributers" from a String, not Attributer.

For example if the code on line 115 in demo project was written like this, the very first "append" would require parameter name.

If it was theoretically written before fix:
```
attributedTextView.attributer = decorate(5) { content in return (content
            + ( "test stroke".append("test stroke\n").strokeWidth(2).strokeColor(UIColor.blue)
                    .append("test strikethrough").strikethrough(2).strikethroughColor(UIColor.red)
                    .append(" test strikethrough\n").strikethrough(2).strikethroughColor(UIColor.yellow)
                    + "expansion\n".expansion(0.8).paragraphAlignRight.paragraphApplyStyling
                    + ("letterpress ".letterpress
                        + " obliquenes\n".obliqueness(0.4).backgroundColor(UIColor.cyan)).paragraphAlignRight.paragraphApplyStyling
                ).all.size(24)
            )
        }
```
After the fix it would need to be written this way (note `"test stroke".append(string: "test stroke\n")` there):
```
attributedTextView.attributer = decorate(5) { content in return (content
            + ( "test stroke".append(string: "test stroke\n").strokeWidth(2).strokeColor(UIColor.blue)
                    .append("test strikethrough").strikethrough(2).strikethroughColor(UIColor.red)
                    .append(" test strikethrough\n").strikethrough(2).strikethroughColor(UIColor.yellow)
                    + "expansion\n".expansion(0.8).paragraphAlignRight.paragraphApplyStyling
                    + ("letterpress ".letterpress
                        + " obliquenes\n".obliqueness(0.4).backgroundColor(UIColor.cyan)).paragraphAlignRight.paragraphApplyStyling
                ).all.size(24)
            )
        }
```