### PR TITLE
Added Swift Package Manager support

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Package.swift
+++ b/Package.swift
@@ -5,11 +5,21 @@
 //  Created by Edwin Vermeer on 23/10/15.
 //  Copyright © 2016 evermeer. All rights reserved.
 //
-
+// swift-tools-version:5.5
 import PackageDescription
 
+let packageName = "AttributedTextView",
 let package = Package(
-    name: "AttributedTextView",
-    dependencies: [],
+    name: packageName,
+    platforms: [
+        .iOS(.v8),
+    ],
+    products: [
+        .library(name: packageName, targets: [packageName])
+    ],
+    dependencies: [
+        // Stub
+    ],
+    target(name: packageName, path: "AttributedTextView/Sources")
     exclude: ["Tests"]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,25 +1,32 @@
+// swift-tools-version:5.5
 //
 //  AttributedTextView.swift
 //  Restofire
 //
 //  Created by Edwin Vermeer on 23/10/15.
 //  Copyright © 2016 evermeer. All rights reserved.
-//
-// swift-tools-version:5.5
+
 import PackageDescription
 
-let packageName = "AttributedTextView",
+let packageName = "AttributedTextView"
 let package = Package(
     name: packageName,
     platforms: [
         .iOS(.v8),
     ],
     products: [
-        .library(name: packageName, targets: [packageName])
+        .library(
+            name: packageName,
+            targets: [packageName]
+        )
     ],
     dependencies: [
         // Stub
     ],
-    target(name: packageName, path: "AttributedTextView/Sources")
-    exclude: ["Tests"]
+    targets: [
+        .target(
+            name: packageName,
+            path: "Sources"
+        ),
+    ]
 )

--- a/Readme.md
+++ b/Readme.md
@@ -346,18 +346,13 @@ github "evermeer/AttributedTextView" ~> 0.5.1
 ```
 ### Swift Package Manager
 
-To use AttributedTextView as a [Swift Package Manager](https://swift.org/package-manager/) package just add the following in your Package.swift file.
+To use AttributedTextView as a [Swift Package Manager](https://swift.org/package-manager/) package just add the following URL in your project file:
 
-``` swift
-import PackageDescription
-
-let package = Package(
-name: "HelloAttributedTextView",
-dependencies: [
-.Package(url: "https://github.com/evermeer/AttributedTextView.git", "0.5.1")
-]
-)
 ```
+https://github.com/evermeer/AttributedTextView
+```
+
+And specify a version from `1.4.1` and onwards. 
 
 ### Manually
 


### PR DESCRIPTION
# Description

This was already available according to the readme, but didn't work properly yet. With these changes it does. Fixes #36 

⚠️ **Note:** I've now updated the Readme to specify version `1.4.1` or higher, so after merging this needs to be tagged on the main repo so we can use that version. I don't think I can do the tagging in my PR to get transferred? 